### PR TITLE
Add CGViz link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Applications of computational geometry include computer-aided design, robotics, 
 - [Point/Line Duality](https://people.eng.unimelb.edu.au/henli/programs/duality-demo/) - A type of mathematical duality frequently used in computational geometry algorithms.
 - [k-d tree](https://opendsa-server.cs.vt.edu/ODSA/AV/Development/kd-treeAV.html?selfLoggingEnabled=false&localMode=false&module=KDtree&JXOP-debug=true&JOP-lang=en&JXOP-code=java&scoringServerEnabled=false&threshold=1.0&points=0&required=False) - A method of partitioning k-dimensional space in an efficient way for searches like nearest neighbors.
 - [Configuration Space](https://www.youtube.com/watch?v=SBFwgR4K1Gk) - The space of possible configurations of an object like a robot.
+- [CGViz: Computational Geometry Interactive Visualizations](https://jes24.github.io/CGViz/) [(GitHub](https://github.com/JeS24/CGViz)] - CGViz is a web app for step-by-step visualizations of many algorithms, designed for exploration, teaching, and creating exportable visuals.
 
 ## Books
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ Applications of computational geometry include computer-aided design, robotics, 
 - [Kirkpatrick's Point location](http://rkaneriya.github.io/point-location/) - A data structure and method for point location with O(n) space and O(log n) query time using triangulation.
 - [Voronoi Diagrams](http://alexbeutel.com/webgl/voronoi.html) - A partition of a plane into regions close to a given set of points.
 - [Fortune's Algorithm](https://www.desmos.com/calculator/ejatebvup4) - A sweep line algorithm for generating the Voronoi diagram in O(n log n) time and O(n) space.
-- [Point/Line Duality](https://people.eng.unimelb.edu.au/henli/programs/duality-demo/) - A type of mathematical duality frequently used in computational geometry algorithms.
-- [k-d tree](https://opendsa-server.cs.vt.edu/ODSA/AV/Development/kd-treeAV.html?selfLoggingEnabled=false&localMode=false&module=KDtree&JXOP-debug=true&JOP-lang=en&JXOP-code=java&scoringServerEnabled=false&threshold=1.0&points=0&required=False) - A method of partitioning k-dimensional space in an efficient way for searches like nearest neighbors.
+- [k-d tree (Wayback Machine)](https://web.archive.org/web/20250209182314/https://opendsa-server.cs.vt.edu/ODSA/AV/Development/kd-treeAV.html?selfLoggingEnabled=false&localMode=false&module=KDtree&JXOP-debug=true&JOP-lang=en&JXOP-code=java&scoringServerEnabled=false&threshold=1.0&points=0&required=False) - A method of partitioning k-dimensional space in an efficient way for searches like nearest neighbors.
 - [Configuration Space](https://www.youtube.com/watch?v=SBFwgR4K1Gk) - The space of possible configurations of an object like a robot.
-- [CGViz: Computational Geometry Interactive Visualizations](https://jes24.github.io/CGViz/) [(GitHub](https://github.com/JeS24/CGViz)] - CGViz is a web app for step-by-step visualizations of many algorithms, designed for exploration, teaching, and creating exportable visuals.
+- [CGViz: Computational Geometry Interactive Visualizations](https://jes24.github.io/CGViz/) ([GitHub Repo](https://github.com/JeS24/CGViz)) - CGViz is a FOSS web app for step-by-step visualizations of many algorithms, designed for exploration, teaching, and creating exportable visuals.
 
 ## Books
 


### PR DESCRIPTION
Added the links.

---

Also, a quick note: the following two links under Algorithms are no longer accessible:

- k-d Tree – https://opendsa-server.cs.vt.edu/ODSA/AV/Development/kd-treeAV.html?selfLoggingEnabled=false\&localMode=false\&module=KDtree\&JXOP-debug=true\&JOP-lang=en\&JXOP-code=java\&scoringServerEnabled=false\&threshold=1.0\&points=0\&required=False
- Point/Line Duality – https://people.eng.unimelb.edu.au/henli/programs/duality-demo/

For the k-d Tree visualizer, the [Wayback Machine](https://web.archive.org/web/20250209182314/https://opendsa-server.cs.vt.edu/ODSA/AV/Development/kd-treeAV.html?selfLoggingEnabled=false&localMode=false&module=KDtree&JXOP-debug=true&JOP-lang=en&JXOP-code=java&scoringServerEnabled=false&threshold=1.0&points=0&required=False) still has a partially functional version, but the Point/Line Duality app is completely broken. Even archived versions (like [this one from 2021](https://web.archive.org/web/20210506135459/https://people.eng.unimelb.edu.au/henli/programs/duality-demo/)) no longer work.

If you want, I can edit these links out, perhaps replacing the k-d Tree one with the Wayback Machine link?